### PR TITLE
reduce max steps

### DIFF
--- a/gym_minigrid/envs/doorkeywithobstacles.py
+++ b/gym_minigrid/envs/doorkeywithobstacles.py
@@ -20,7 +20,7 @@ class DoorKeyObstEnv(MiniGridEnv):
 
         super().__init__(
             grid_size=size,
-            max_steps=10 * size * size
+            max_steps=4 * size * size
         )
 
         # Only 5 actions permitted: left, right, forward, pickup, tooggle

--- a/gym_minigrid/envs/doorkeywithobstacles.py
+++ b/gym_minigrid/envs/doorkeywithobstacles.py
@@ -20,7 +20,7 @@ class DoorKeyObstEnv(MiniGridEnv):
 
         super().__init__(
             grid_size=size,
-            max_steps=4 * size * size
+            max_steps=5 * size * size
         )
 
         # Only 5 actions permitted: left, right, forward, pickup, tooggle


### PR DESCRIPTION
Sometimes the algorithm does not converge and the agent gets stuck avoiding obstacles, getting 0 reward. That means these algorithms run max steps for a long time. That's why they are taking longer to process.
My suggestion is to reduce max steps. In this case the agent will either terminate in a obstacle -1, terminate in the goal +1, or "avoid" obstacles during less steps.
 